### PR TITLE
Applies changes to git secret handling to match cli changes

### DIFF
--- a/tasks/2-build-tag-push.yaml
+++ b/tasks/2-build-tag-push.yaml
@@ -56,11 +56,15 @@ spec:
               PRE_RELEASE="--preRelease=${BRANCH}"
           fi
 
-          release-it patch --ci --no-npm ${PRE_RELEASE} \
-            --hooks.after:release='echo "IMAGE_VERSION=${version}" > ./env-config' \
+
+          release-it patch ${PRE_RELEASE} \
+            --ci \
+            --no-npm \
+            --no-git.requireCleanWorkingDir \
             --verbose \
             -VV
 
+          echo "IMAGE_VERSION=$(git describe --abbrev=0 --tags)" > ./env-config
           echo "IMAGE_NAME=$(basename -s .git `git config --get remote.origin.url` | tr '[:upper:]' '[:lower:]' | sed 's/_/-/g')" >> ./env-config
 
           source ./env-config

--- a/tasks/6-gitops.yaml
+++ b/tasks/6-gitops.yaml
@@ -44,7 +44,7 @@ spec:
         - name: HOME
           value: /home/devops
       envFrom:
-        - secretRef:
+        - configMapRef:
             name: gitops-cd-secret
             optional: true
       command: ["/bin/bash"]
@@ -52,26 +52,6 @@ spec:
         - -c
         - |
           set -e
-          if [[ -z "${username}" ]]; then
-              echo "'username' not set. Not triggering CD pipeline"
-              exit 0
-          fi
-          if [[ -z "${password}" ]]; then
-              echo "'password' not set. Not triggering CD pipeline"
-              exit 0
-          fi
-          if [[ -z "${host}" ]]; then
-              echo "'host' not set. Not triggering CD pipeline"
-              exit 0
-          fi
-          if [[ -z "${org}" ]]; then
-              echo "'org' not set. Not triggering CD pipeline"
-              exit 0
-          fi
-          if [[ -z "${repo}" ]]; then
-              echo "'repo' not set. Not triggering CD pipeline"
-              exit 0
-          fi
           if [[ -z "${branch}" ]]; then
               branch="master"
           fi
@@ -82,8 +62,7 @@ spec:
           git config --global user.email "cloud-native-toolkit@example.com"
           git config --global user.name "Cloud Native Toolkit Pipeline"
 
-          GIT_URL="https://${username}:${password}@${host}/${org}/${repo}"
-          git clone -b ${branch} ${GIT_URL} gitops_cd
+          git clone -b ${branch} ${url} gitops_cd
           cd gitops_cd
 
           echo "Requirements before update"


### PR DESCRIPTION
The git credentials should be stored in a secret called `git-credentials` and the config for the git repo (e.g. org, repo, branch) are stored in a config map. By default the config map is named after the repo but the name can be overridden (as in the case of the gitops repo).

For tekton, the authentication to git should be handled automatically so we shouldn't need to worry about it. The configuration for getting the git values needs to change to map from a config map.