### PR TITLE
Tweak to Usage input

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ This step will create following Pipelines:
 - Run a pipeline for one of the application templates using the Tekton CLI `tkn` and the helper script
     
     ```bash
-    Usage: ./test/scripts/run.sh [nodesjs-typescript | nodejs-react | nodejs-angular | java-spring]
+    Usage: ./test/scripts/run.sh [nodejs-typescript | nodejs-react | nodejs-angular | java-spring]
     ```
     For example to run the pipeline for the application template `nodejs-typescript`
     ```bash

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ This step will create following Pipelines:
     ```
     For example to run the pipeline for the application template `nodejs-typescript`
     ```bash
-    ./test/scripts/run.sh nodesjs-typescript
+    ./test/scripts/run.sh nodejs-typescript
     ```
     The script will output the name of the pipelinerun, and a command to follow the logs
     ```

--- a/test/scripts/run.sh
+++ b/test/scripts/run.sh
@@ -18,7 +18,7 @@ elif [ "$1" == "java-spring" ]; then
   GIT="java-spring-git"
   IMAGE="java-spring-image"
 else 
-  echo "Usage: $0 [nodesjs-typescript | nodejs-react | nodejs-angular | java-spring]"
+  echo "Usage: $0 [nodejs-typescript | nodejs-react | nodejs-angular | java-spring]"
   exit 1
 fi
 


### PR DESCRIPTION
The README and run.sh script prompted the user to use "nodesjs-typescript" as a Usage argument. 
However, the script is written such that Usage argument "nodejs-typescript" is what will work. 

I changed the README and run.sh script to reflect that.