### PR TITLE
fix pipeline order for helm-release after scan

### DIFF
--- a/pipelines/java-maven-pipeline.yaml
+++ b/pipelines/java-maven-pipeline.yaml
@@ -147,7 +147,7 @@ spec:
       taskRef:
         name: ibm-helm-release
       runAfter:
-        - img-release
+        - img-scan
       params:
         - name: git-url
           value: "$(tasks.setup.results.git-url)"

--- a/pipelines/nodejs-pipeline.yaml
+++ b/pipelines/nodejs-pipeline.yaml
@@ -149,7 +149,7 @@ spec:
       taskRef:
         name: ibm-helm-release
       runAfter:
-        - img-release
+        - img-scan
       params:
         - name: git-url
           value: "$(tasks.setup.results.git-url)"


### PR DESCRIPTION
@orhanIBM this is the fix for the bug in the order of tasks in some of the pipelines