### PR TITLE
Planning599hadolint

### DIFF
--- a/pipelines/appmod-liberty-pipeline.yaml
+++ b/pipelines/appmod-liberty-pipeline.yaml
@@ -42,11 +42,23 @@ spec:
           value: "$(tasks.setup.results.source-dir)"
         - name: app-name
           value: "$(tasks.setup.results.app-name)"
+    - name: hadolint
+      taskRef:
+        name: ibm-hadolint
+      runAfter:
+        - test
+      params:
+        - name: git-url
+          value: "$(tasks.setup.results.git-url)"
+        - name: git-revision
+          value: "$(tasks.setup.results.git-revision)"
+        - name: source-dir
+          value: "$(tasks.setup.results.source-dir)"
     - name: build
       taskRef:
         name: ibm-build-tag-push
       runAfter:
-        - test
+        - hadolint
       params:
         - name: git-url
           value: "$(tasks.setup.results.git-url)"

--- a/pipelines/golang-pipeline-edge.yaml
+++ b/pipelines/golang-pipeline-edge.yaml
@@ -37,11 +37,23 @@ spec:
           value: "$(tasks.setup.results.source-dir)"
         - name: app-name
           value: "$(tasks.setup.results.app-name)"
+    - name: hadolint
+      taskRef:
+        name: ibm-hadolint
+      runAfter:
+        - test
+      params:
+        - name: git-url
+          value: "$(tasks.setup.results.git-url)"
+        - name: git-revision
+          value: "$(tasks.setup.results.git-revision)"
+        - name: source-dir
+          value: "$(tasks.setup.results.source-dir)"
     - name: build
       taskRef:
         name: ibm-build-tag-push
       runAfter:
-        - test
+        - hadolint
       params:
         - name: git-url
           value: "$(tasks.setup.results.git-url)"

--- a/pipelines/golang-pipeline.yaml
+++ b/pipelines/golang-pipeline.yaml
@@ -37,11 +37,23 @@ spec:
           value: "$(tasks.setup.results.source-dir)"
         - name: app-name
           value: "$(tasks.setup.results.app-name)"
+    - name: hadolint
+      taskRef:
+        name: ibm-hadolint
+      runAfter:
+        - test
+      params:
+        - name: git-url
+          value: "$(tasks.setup.results.git-url)"
+        - name: git-revision
+          value: "$(tasks.setup.results.git-revision)"
+        - name: source-dir
+          value: "$(tasks.setup.results.source-dir)"
     - name: build
       taskRef:
         name: ibm-build-tag-push
       runAfter:
-        - test
+        - hadolint
       params:
         - name: git-url
           value: "$(tasks.setup.results.git-url)"

--- a/pipelines/java-gradle-pipeline.yaml
+++ b/pipelines/java-gradle-pipeline.yaml
@@ -37,11 +37,23 @@ spec:
           value: "$(tasks.setup.results.source-dir)"
         - name: app-name
           value: "$(tasks.setup.results.app-name)"
+    - name: hadolint
+      taskRef:
+        name: ibm-hadolint
+      runAfter:
+        - test
+      params:
+        - name: git-url
+          value: "$(tasks.setup.results.git-url)"
+        - name: git-revision
+          value: "$(tasks.setup.results.git-revision)"
+        - name: source-dir
+          value: "$(tasks.setup.results.source-dir)"
     - name: build
       taskRef:
         name: ibm-build-tag-push
       runAfter:
-        - test
+        - hadolint
       params:
         - name: git-url
           value: "$(tasks.setup.results.git-url)"

--- a/pipelines/java-maven-pipeline.yaml
+++ b/pipelines/java-maven-pipeline.yaml
@@ -37,11 +37,25 @@ spec:
           value: "$(tasks.setup.results.source-dir)"
         - name: app-name
           value: "$(tasks.setup.results.app-name)"
+
+    - name: hadolint
+      taskRef:
+        name: ibm-hadolint
+      runAfter:
+        - test
+      params:
+        - name: git-url
+          value: "$(tasks.setup.results.git-url)"
+        - name: git-revision
+          value: "$(tasks.setup.results.git-revision)"
+        - name: source-dir
+          value: "$(tasks.setup.results.source-dir)"
+
     - name: build
       taskRef:
         name: ibm-build-tag-push
       runAfter:
-        - test
+        - hadolint
       params:
         - name: git-url
           value: "$(tasks.setup.results.git-url)"

--- a/pipelines/nodejs-pipeline.yaml
+++ b/pipelines/nodejs-pipeline.yaml
@@ -39,11 +39,23 @@ spec:
           value: "$(tasks.setup.results.js-image)"
         - name: app-name
           value: $(tasks.setup.results.app-name)
+    - name: hadolint
+      taskRef:
+        name: ibm-hadolint
+      runAfter:
+        - test
+      params:
+        - name: git-url
+          value: "$(tasks.setup.results.git-url)"
+        - name: git-revision
+          value: "$(tasks.setup.results.git-revision)"
+        - name: source-dir
+          value: "$(tasks.setup.results.source-dir)"
     - name: build
       taskRef:
         name: ibm-build-tag-push
       runAfter:
-        - test
+        - hadolint
       params:
         - name: git-url
           value: "$(tasks.setup.results.git-url)"

--- a/tasks/2-lint.yaml
+++ b/tasks/2-lint.yaml
@@ -77,7 +77,6 @@ spec:
           cat ${FILE}
           hadolint --config ${HADOLINT_CFG} $(params.DOCKERFILE)
 
-        
         elif [ ! -f "${FILE}" ]; then
           echo "Skipping Dockerfile lint step, given that no hadolint configuration file is found"
           exit 0
@@ -88,7 +87,7 @@ spec:
           hadolint $(params.DOCKERFILE)
         fi
 
-          echo "For more information about hadolint please refer to https://cloudnativetoolkit.dev/ "
+        echo "For more information about hadolint please refer to https://cloudnativetoolkit.dev/ "
 
         set -x
 

--- a/tasks/2-lint.yaml
+++ b/tasks/2-lint.yaml
@@ -90,4 +90,3 @@ spec:
         echo "For more information about hadolint please refer to https://cloudnativetoolkit.dev/ "
 
         set -x
-

--- a/tasks/2-lint.yaml
+++ b/tasks/2-lint.yaml
@@ -1,0 +1,75 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: ibm-hadolint
+  annotations:
+    description: Executes logic to build, tag and push a container image using the intermediate sha tag to the image-url
+    app.openshift.io/description: Executes logic to build, tag and push a container image using the intermediate sha tag to the image-url
+    app.openshift.io/vcs-uri: https://github.com/IBM/ibm-garage-tekton-tasks
+    app.openshift.io/vcs-ref: master
+  labels:
+    version: 0.0.0
+spec:
+  params:
+    - name: git-url
+    - name: git-revision
+      default: master
+    - name: source-dir
+      default: /source
+    - name: DOCKERFILE
+      default: Dockerfile
+    - name: CONTEXT
+      default: .
+    - name: LINT_IMAGE
+      default: hadolint/hadolint
+  volumes:
+    - name: source
+      emptyDir: {}
+  stepTemplate:
+    volumeMounts:
+      - name: source
+        mountPath: $(params.source-dir)
+  steps:
+    - name: git-clone
+      image: alpine/git
+      env:
+        - name: GIT_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: git-credentials
+              key: password
+              optional: true
+        - name: GIT_USERNAME
+          valueFrom:
+            secretKeyRef:
+              name: git-credentials
+              key: username
+              optional: true
+      script: |
+        set +x
+        if [[ -n "${GIT_USERNAME}" ]] && [[ -n "${GIT_PASSWORD}" ]]; then
+            git clone "https://${GIT_USERNAME}:${GIT_PASSWORD}@$(echo $(params.git-url) | awk -F 'https://' '{print $2}')" $(params.source-dir)
+        else
+            set -x
+            git clone $(params.git-url) $(params.source-dir)
+        fi
+        set -x
+        cd $(params.source-dir)
+        git checkout $(params.git-revision)
+    - name: lint
+      image: $(params.LINT_IMAGE)
+      workingdir: $(params.source-dir)      
+      env:
+        - name: HADOLINT_CFG
+          valueFrom:
+            configMapKeyRef:
+              name: hadolint-config
+              key: HADOLINT_CFG
+              optional: true
+      script: | 
+        if [ -n "${HADOLINT_CFG}" ]; then
+          hadolint --config ${HADOLINT_CFG} $(params.DOCKERFILE)
+        else
+          hadolint $(params.DOCKERFILE)
+        fi
+

--- a/tasks/2-lint.yaml
+++ b/tasks/2-lint.yaml
@@ -3,8 +3,8 @@ kind: Task
 metadata:
   name: ibm-hadolint
   annotations:
-    description: Executes logic to build, tag and push a container image using the intermediate sha tag to the image-url
-    app.openshift.io/description: Executes logic to build, tag and push a container image using the intermediate sha tag to the image-url
+    description: Optional linter for Dockerfiles; if a ".hadolint" file is in the repo root, this task automatically picks up; otherwise hadolint file name must be passed via ConfigMap. See Hadolint on Dockerhub for more
+    app.openshift.io/description: Optional linter for Dockerfiles; if a ".hadolint" file is in the repo root, this task automatically picks up; otherwise hadolint file name must be passed via ConfigMap
     app.openshift.io/vcs-uri: https://github.com/IBM/ibm-garage-tekton-tasks
     app.openshift.io/vcs-ref: master
   labels:
@@ -67,9 +67,28 @@ spec:
               key: HADOLINT_CFG
               optional: true
       script: | 
-        if [ -n "${HADOLINT_CFG}" ]; then
+        set +x
+
+        FILE="$(params.source-dir)"/.hadolint.yaml
+
+        if [ -f "${HADOLINT_CFG}" ]; then
+          FILE="$(params.source-dir)/${HADOLINT_CFG}"
+          echo "In this step, hadolint will lint your Dockerfile, using ${FILE}, with the following rules: "
+          cat ${FILE}
           hadolint --config ${HADOLINT_CFG} $(params.DOCKERFILE)
+
+        
+        elif [ ! -f "${FILE}" ]; then
+          echo "Skipping Dockerfile lint step, given that no hadolint configuration file is found"
+          exit 0
+        
         else
+          echo "In this step, hadolint will lint your Dockerfile, using .hadolint.yaml, with the following rules: "
+          cat "${FILE}"
           hadolint $(params.DOCKERFILE)
         fi
+
+          echo "For more information about hadolint please refer to https://cloudnativetoolkit.dev/ "
+
+        set -x
 


### PR DESCRIPTION
The initial implementation of hadolint with the following logic:

The implementation assumes that user will have '.hadolint' configuration file by default in the root. If the user passes a different hadolint configuration file name and/or path, it should be passed via configMap to the task, the task will refer to such custom filename/filepath. If the task cannot find either, it assumes that no hadolint configuration is available, it will skip the task.

If user provides a custom hadolint name, but does not input it in configMap, unfortunately, task assumes that there's no hadolint configuration in the task.

The task displays the configuration file on the logs (cat hadolint file), as well, if there is any lint error, then the pipeline run stops.

The sample configMap, where hadolint configuration is saved under 'myhadolint.yaml' file, should look like this:

kind: ConfigMap
apiVersion: v1
metadata:
  name: hadolint-config
data:
  HADOLINT_CFG: myhadolint.yaml


Todos:
Please note that starter kit templates are not yet updated, so I would recommend accepting this change after starter kits are updated (that's my responsibility, working on it).

I will also write the FAQ for the cloudnativetoolkit.dev to explain how to configure this task.