### PR TITLE
Updates for ibmcloud-dev image

### DIFF
--- a/tasks/0-setup.yaml
+++ b/tasks/0-setup.yaml
@@ -59,7 +59,7 @@ spec:
       description: Flag indicating that a Vulnerability Advisor scan should be performed
       default: "false"
     - name: tools-image
-      default: quay.io/ibmgaragecloud/ibmcloud-dev:v2.0.1
+      default: quay.io/ibmgaragecloud/ibmcloud-dev:v2.0.4
     - name: js-image
       default: quay.io/ibmgaragecloud/node:lts-stretch
   results:

--- a/tasks/10-gitops-edge.yaml
+++ b/tasks/10-gitops-edge.yaml
@@ -23,7 +23,7 @@ spec:
     - name: version
       default: ""
     - name: tools-image
-      default: quay.io/ibmgaragecloud/ibmcloud-dev:v2.0.1
+      default: quay.io/ibmgaragecloud/ibmcloud-dev:v2.0.4
   volumes:
     - name: source
       emptyDir: {}

--- a/tasks/10-gitops.yaml
+++ b/tasks/10-gitops.yaml
@@ -26,7 +26,7 @@ spec:
     - name: helm-url
       default: ""
     - name: tools-image
-      default: quay.io/ibmgaragecloud/ibmcloud-dev:v2.0.1
+      default: quay.io/ibmgaragecloud/ibmcloud-dev:v2.0.4
   volumes:
     - name: source
       emptyDir: {}
@@ -171,10 +171,12 @@ spec:
             echo "Requirements before update"
             cat "${SUBDIR}/${YAML_FILE}"
 
-            # TODO avoid using igc to use yq
-            npm i -g @garage-catalyst/ibm-garage-cloud-cli
-            igc yq w "${SUBDIR}/${YAML_FILE}" "dependencies[?(@.name == '${APP_NAME}')].version" ${VERSION} -i
-            igc yq w "${SUBDIR}/${YAML_FILE}" "dependencies[?(@.name == '${APP_NAME}')].repository" ${HELM_URL} -i
+            yq r "${SUBDIR}/${YAML_FILE}" -j | \
+              jq --arg APP_NAME "${APP_NAME}" --arg VERSION "${VERSION}" --arg REPO "${HELM_URL}" '.dependencies |= map((select(.name == $APP_NAME) | .version = $VERSION | .repository = $REPO) // .)' | \
+              yq p --prettyPrint - > "${SUBDIR}/${YAML_FILE}.new"
+
+            rm "${SUBDIR}/${YAML_FILE}"
+            mv "${SUBDIR}/${YAML_FILE}.new" "${SUBDIR}/${YAML_FILE}"
 
             echo "Requirements after update"
             cat "${SUBDIR}/${YAML_FILE}"

--- a/tasks/3-img-scan-ibm.yaml
+++ b/tasks/3-img-scan-ibm.yaml
@@ -17,7 +17,7 @@ spec:
       description: Flag indicating that a scan should be performed
       default: "false"
     - name: tools-image
-      default: quay.io/ibmgaragecloud/ibmcloud-dev:v2.0.1
+      default: quay.io/ibmgaragecloud/ibmcloud-dev:v2.0.4
     - name: source-dir
       default: /source
   volumes:

--- a/tasks/3-operator-catalog-gitops.yaml
+++ b/tasks/3-operator-catalog-gitops.yaml
@@ -31,7 +31,7 @@ spec:
     - name: image-url
       default: ""
     - name: tools-image
-      default: quay.io/ibmgaragecloud/ibmcloud-dev:v2.0.1
+      default: quay.io/ibmgaragecloud/ibmcloud-dev:v2.0.4
   volumes:
     - name: source
       emptyDir: {}

--- a/tasks/4-deploy.yaml
+++ b/tasks/4-deploy.yaml
@@ -31,7 +31,7 @@ spec:
     - name: deploy-ingress-type
       default: "route"
     - name: tools-image
-      default: quay.io/ibmgaragecloud/ibmcloud-dev:v2.0.1
+      default: quay.io/ibmgaragecloud/ibmcloud-dev:v2.0.4
   results:
     - name: service-port
   volumes:

--- a/tasks/5-health-check.yaml
+++ b/tasks/5-health-check.yaml
@@ -26,7 +26,7 @@ spec:
     - name: health-curl
       default: "-k"
     - name: tools-image
-      default: quay.io/ibmgaragecloud/ibmcloud-dev:v2.0.1
+      default: quay.io/ibmgaragecloud/ibmcloud-dev:v2.0.4
   steps:
     - name: health-check
       image: $(params.tools-image)

--- a/tasks/7-operator-gitops.yaml
+++ b/tasks/7-operator-gitops.yaml
@@ -24,7 +24,7 @@ spec:
     - name: image-url
       default: ""
     - name: tools-image
-      default: quay.io/ibmgaragecloud/ibmcloud-dev:v2.0.1
+      default: quay.io/ibmgaragecloud/ibmcloud-dev:v2.0.4
   volumes:
     - name: source
       emptyDir: {}

--- a/tasks/9-helm-release.yaml
+++ b/tasks/9-helm-release.yaml
@@ -25,7 +25,7 @@ spec:
     - name: helm-curl
       default: ""
     - name: tools-image
-      default: quay.io/ibmgaragecloud/ibmcloud-dev:v2.0.1
+      default: quay.io/ibmgaragecloud/ibmcloud-dev:v2.0.4
   results:
     - name: helm-url
       description: The url of the helm repository

--- a/tasks/9-img-scan.yaml
+++ b/tasks/9-img-scan.yaml
@@ -26,7 +26,7 @@ spec:
     - name: TRIVY_IMAGE
       default: quay.io/ibmgaragecloud/aquasec-trivy
     - name: tools-image
-      default: quay.io/ibmgaragecloud/ibmcloud-dev:v2.0.1
+      default: quay.io/ibmgaragecloud/ibmcloud-dev:v2.0.4
   volumes:
     - name: oci-image
       emptyDir: {}


### PR DESCRIPTION
- Bumps version to v2.0.4 to fix permissions issue in home directory
- Updates gitops task to remove "igc yq" dependency and do the equivalent with a combination of yq and jq