### PR TITLE
Add check for >1 Chart*.yaml.

### DIFF
--- a/tasks/4-deploy.yaml
+++ b/tasks/4-deploy.yaml
@@ -111,7 +111,13 @@ spec:
           export CHART_ROOT=$(find . -name chart)
           echo "CHART_ROOT: $CHART_ROOT"
 
-          export CHART=$(find . -name Chart*.yaml)
+          FILE_NUM=$(find . -name 'Chart*.yaml' |wc -l)
+          if [[ "${FILE_NUM}" -gt 1 ]]; then
+            echo "Error: Found >1 Chart*.yaml"
+            exit 1
+          fi
+
+          export CHART=$(find . -name 'Chart*.yaml')
           echo "CHART: $CHART"
 
           export CHART_NAME=$(cat $CHART | awk '/name:/ {print $2}')


### PR DESCRIPTION
If there is more than one file with a name matching Chart*.yaml,
the script will fail.