### PR TITLE
fix workingdir spelling for argocd

### DIFF
--- a/tasks/1-golang-test.yaml
+++ b/tasks/1-golang-test.yaml
@@ -58,17 +58,17 @@ spec:
         git checkout $(params.git-revision)
     - name: build
       image: $(params.golang-image)
-      workingdir: $(params.source-dir)
+      workingDir: $(params.source-dir)
       script: |
           go build ./...
     - name: test
       image: $(params.golang-image)
-      workingdir: $(params.source-dir)
+      workingDir: $(params.source-dir)
       script: |
           go test ./...
     - name: sonar-scan
       image: $(params.sonarqube-cli)
-      workingdir: $(params.source-dir)
+      workingDir: $(params.source-dir)
       env:
         - name: SONAR_USER_HOME
           value: $(params.source-dir)

--- a/tasks/1-java-gradle-test.yaml
+++ b/tasks/1-java-gradle-test.yaml
@@ -63,17 +63,17 @@ spec:
         git checkout $(params.git-revision)
     - name: build
       image: $(params.gradle-image)
-      workingdir: $(params.source-dir)
+      workingDir: $(params.source-dir)
       script: |
           ./gradlew assemble --no-daemon
     - name: test
       image: $(params.gradle-image)
-      workingdir: $(params.source-dir)
+      workingDir: $(params.source-dir)
       script: |
           ./gradlew testClasses --no-daemon
     - name: sonar-scan
       image: $(params.sonarqube-cli)
-      workingdir: $(params.source-dir)
+      workingDir: $(params.source-dir)
       env:
         - name: SONAR_USER_HOME
           value: $(params.source-dir)

--- a/tasks/1-java-maven-test.yaml
+++ b/tasks/1-java-maven-test.yaml
@@ -60,7 +60,7 @@ spec:
         git checkout $(params.git-revision)
     - name: build
       image: $(params.maven-image)
-      workingdir: $(params.source-dir)
+      workingDir: $(params.source-dir)
       script: |
         if [[ -f "./mvnw" ]]; then
           ./mvnw package
@@ -69,7 +69,7 @@ spec:
         fi
     - name: test
       image: $(params.maven-image)
-      workingdir: $(params.source-dir)
+      workingDir: $(params.source-dir)
       script: |
         if [[ -f "./mvnw" ]]; then
           ./mvnw test
@@ -78,7 +78,7 @@ spec:
         fi
     - name: sonar-scan
       image: $(params.sonarqube-cli)
-      workingdir: $(params.source-dir)
+      workingDir: $(params.source-dir)
       env:
         - name: SONAR_USER_HOME
           value: $(params.source-dir)

--- a/tasks/1-nodejs-test.yaml
+++ b/tasks/1-nodejs-test.yaml
@@ -58,7 +58,7 @@ spec:
         git checkout $(params.git-revision)
     - name: build
       image: $(params.js-image)
-      workingdir: $(params.source-dir)
+      workingDir: $(params.source-dir)
       env:
       - name: npm_config_registry
         valueFrom:
@@ -76,12 +76,12 @@ spec:
         npm run build --if-present
     - name: test
       image: $(params.js-image)
-      workingdir: $(params.source-dir)
+      workingDir: $(params.source-dir)
       script: |
         CI=true npm test
     - name: publish-pact
       image: $(params.js-image)
-      workingdir: $(params.source-dir)
+      workingDir: $(params.source-dir)
       env:
         - name: PACTBROKER_URL
           valueFrom:
@@ -97,7 +97,7 @@ spec:
         fi
     - name: verify-pact
       image: $(params.js-image)
-      workingdir: $(params.source-dir)
+      workingDir: $(params.source-dir)
       env:
         - name: PACTBROKER_URL
           valueFrom:
@@ -113,7 +113,7 @@ spec:
         fi
     - name: sonar-scan
       image: $(params.sonarqube-cli)
-      workingdir: $(params.source-dir)
+      workingDir: $(params.source-dir)
       env:
         - name: SONAR_USER_HOME
           value: $(params.source-dir)

--- a/tasks/1-operator-test.yaml
+++ b/tasks/1-operator-test.yaml
@@ -56,6 +56,6 @@ spec:
         git checkout $(params.git-revision)
     - name: test
       image: $(params.build-image)
-      workingdir: $(params.source-dir)
+      workingDir: $(params.source-dir)
       script: |
         make test

--- a/tasks/10-gitops-edge.yaml
+++ b/tasks/10-gitops-edge.yaml
@@ -66,7 +66,7 @@ spec:
         git checkout $(params.git-revision)
     - name: gitops-edge
       image: $(params.tools-image)
-      workingdir: $(params.source-dir)
+      workingDir: $(params.source-dir)
       securityContext:
         allowPrivilegeEscalation : true
       env:

--- a/tasks/10-gitops.yaml
+++ b/tasks/10-gitops.yaml
@@ -37,7 +37,7 @@ spec:
   steps:
     - name: gitops
       image: $(params.tools-image)
-      workingdir: $(params.source-dir)
+      workingDir: $(params.source-dir)
       env:
         - name: NAMESPACE
           valueFrom:

--- a/tasks/2-build-tag-push.yaml
+++ b/tasks/2-build-tag-push.yaml
@@ -75,7 +75,7 @@ spec:
         git checkout $(params.git-revision)
     - name: build
       image: $(params.BUILDER_IMAGE)
-      workingdir: $(params.source-dir)
+      workingDir: $(params.source-dir)
       env:
         - name: REGISTRY_USER
           valueFrom:

--- a/tasks/2-lint.yaml
+++ b/tasks/2-lint.yaml
@@ -61,7 +61,7 @@ spec:
         git checkout $(params.git-revision)
     - name: lint
       image: $(params.LINT_IMAGE)
-      workingdir: $(params.source-dir)      
+      workingDir: $(params.source-dir)      
       env:
         - name: HADOLINT_CFG
           valueFrom:

--- a/tasks/2-operator-catalog-build.yaml
+++ b/tasks/2-operator-catalog-build.yaml
@@ -75,7 +75,7 @@ spec:
         git checkout $(params.git-revision)
     - name: generate-catalog
       image: $(params.OPM_IMAGE)
-      workingdir: $(params.source-dir)
+      workingDir: $(params.source-dir)
       env:
         - name: REGISTRY_URL
           valueFrom:
@@ -137,7 +137,7 @@ spec:
         opm index add ${SKIPTLS} --bundles "${BUNDLES}" --generate -d $(params.DOCKERFILE)
     - name: build
       image: $(params.BUILDER_IMAGE)
-      workingdir: $(params.source-dir)
+      workingDir: $(params.source-dir)
       env:
         - name: REGISTRY_USER
           valueFrom:

--- a/tasks/3-img-scan-ibm.yaml
+++ b/tasks/3-img-scan-ibm.yaml
@@ -30,7 +30,7 @@ spec:
   steps:
     - name: scan-image
       image: $(params.tools-image)
-      workingdir: $(params.source-dir)
+      workingDir: $(params.source-dir)
       env:
         - name: HOME
           value: /home/devops

--- a/tasks/3-operator-catalog-gitops.yaml
+++ b/tasks/3-operator-catalog-gitops.yaml
@@ -72,7 +72,7 @@ spec:
         git checkout $(params.git-revision)
     - name: gitops
       image: $(params.tools-image)
-      workingdir: $(params.gitops-dir)
+      workingDir: $(params.gitops-dir)
       env:
         - name: NAMESPACE
           valueFrom:

--- a/tasks/4-deploy.yaml
+++ b/tasks/4-deploy.yaml
@@ -71,7 +71,7 @@ spec:
         git checkout $(params.git-revision)
     - name: deploy
       image: $(params.tools-image)
-      workingdir: $(params.source-dir)
+      workingDir: $(params.source-dir)
       env:
         - name: TLS_SECRET_NAME
           valueFrom:

--- a/tasks/6-java-contract-test.yaml
+++ b/tasks/6-java-contract-test.yaml
@@ -59,7 +59,7 @@ spec:
         git checkout $(params.git-revision)
     - name: pact-verify
       image: $(params.gradle-image)
-      workingdir: $(params.source-dir)
+      workingDir: $(params.source-dir)
       env:
         - name: GRADLE_USER_HOME
           value: $(params.source-dir)

--- a/tasks/6-operator-bundle.yaml
+++ b/tasks/6-operator-bundle.yaml
@@ -79,7 +79,7 @@ spec:
         git checkout $(params.git-revision)
     - name: build
       image: $(params.BUNDLE_IMAGE)
-      workingdir: $(params.source-dir)
+      workingDir: $(params.source-dir)
       env:
         - name: REGISTRY_USER
           valueFrom:

--- a/tasks/7-operator-gitops.yaml
+++ b/tasks/7-operator-gitops.yaml
@@ -35,7 +35,7 @@ spec:
   steps:
     - name: gitops
       image: $(params.tools-image)
-      workingdir: $(params.source-dir)
+      workingDir: $(params.source-dir)
       env:
         - name: NAMESPACE
           valueFrom:

--- a/tasks/7-tag-release.yaml
+++ b/tasks/7-tag-release.yaml
@@ -64,7 +64,7 @@ spec:
         git switch -c local
     - name: git-tag
       image: $(params.js-image)
-      workingdir: $(params.source-dir)
+      workingDir: $(params.source-dir)
       script: |
         #!/usr/bin/env bash
         set -ex

--- a/tasks/9-helm-release.yaml
+++ b/tasks/9-helm-release.yaml
@@ -65,7 +65,7 @@ spec:
         git checkout $(params.git-revision)
     - name: package-helm
       image: $(params.tools-image)
-      workingdir: $(params.source-dir)
+      workingDir: $(params.source-dir)
       env:
         - name: TLS_SECRET_NAME
           valueFrom:


### PR DESCRIPTION
this change is needed it for argocd gitops, because the tekton controller will mutate the field from workingdir to workingDir, and this will be a diff that argocd will try to revert based on the value from git