### PR TITLE
Hadolint fix

### DIFF
--- a/pipelines/appmod-liberty-pipeline.yaml
+++ b/pipelines/appmod-liberty-pipeline.yaml
@@ -55,9 +55,9 @@ spec:
           value: "$(tasks.setup.results.app-name)"
         - name: sonarqube-java-bin-path
           value: "$(params.java-bin-path)"
-    - name: hadolint
+    - name: dockerfile-lint
       taskRef:
-        name: ibm-hadolint
+        name: ibm-dockerfile-lint
       runAfter:
         - test
       params:
@@ -73,7 +73,7 @@ spec:
       taskRef:
         name: ibm-build-tag-push
       runAfter:
-        - hadolint
+        - dockerfile-lint
       params:
         - name: git-url
           value: "$(tasks.setup.results.git-url)"

--- a/pipelines/general-pipeline.yaml
+++ b/pipelines/general-pipeline.yaml
@@ -16,6 +16,9 @@ spec:
     - name: lint-dockerfile
       description: Enable the pipeline to lint the Dockerfile for best practices
       default: "true"
+    - name: health-endpoint
+      description: Endpoint to check health after deployment, defaults /
+      default: "/"
   tasks:
     - name: setup
       taskRef:
@@ -27,6 +30,8 @@ spec:
           value: $(params.git-revision)
         - name: scan-image
           value: $(params.scan-image)
+        - name: health-endpoint
+          value: $(params.health-endpoint)
         - name: lint-dockerfile
           value: $(params.lint-dockerfile)
     - name: code-lint
@@ -47,7 +52,7 @@ spec:
       taskRef:
         name: ibm-dockerfile-lint
       runAfter:
-        - test
+        - code-lint
       params:
         - name: git-url
           value: "$(tasks.setup.results.git-url)"

--- a/pipelines/general-pipeline.yaml
+++ b/pipelines/general-pipeline.yaml
@@ -43,9 +43,9 @@ spec:
           value: "$(tasks.setup.results.source-dir)"
         - name: app-name
           value: $(tasks.setup.results.app-name)
-    - name: hadolint
+    - name: dockerfile-lint
       taskRef:
-        name: ibm-hadolint
+        name: ibm-dockerfile-lint
       runAfter:
         - test
       params:
@@ -61,7 +61,7 @@ spec:
       taskRef:
         name: ibm-build-tag-push
       runAfter:
-        - hadolint
+        - dockerfile-lint
       params:
         - name: git-url
           value: "$(tasks.setup.results.git-url)"

--- a/pipelines/general-pipeline.yaml
+++ b/pipelines/general-pipeline.yaml
@@ -29,7 +29,7 @@ spec:
           value: $(params.scan-image)
         - name: lint-dockerfile
           value: $(params.lint-dockerfile)
-    - name: test
+    - name: code-lint
       taskRef:
         name: ibm-sonar-test
       runAfter:

--- a/pipelines/golang-pipeline-edge.yaml
+++ b/pipelines/golang-pipeline-edge.yaml
@@ -44,9 +44,9 @@ spec:
           value: "$(tasks.setup.results.source-dir)"
         - name: app-name
           value: "$(tasks.setup.results.app-name)"
-    - name: hadolint
+    - name: dockerfile-lint
       taskRef:
-        name: ibm-hadolint
+        name: ibm-dockerfile-lint
       runAfter:
         - test
       params:
@@ -62,7 +62,7 @@ spec:
       taskRef:
         name: ibm-build-tag-push
       runAfter:
-        - hadolint
+        - dockerfile-lint
       params:
         - name: git-url
           value: "$(tasks.setup.results.git-url)"

--- a/pipelines/golang-pipeline.yaml
+++ b/pipelines/golang-pipeline.yaml
@@ -44,9 +44,9 @@ spec:
           value: "$(tasks.setup.results.source-dir)"
         - name: app-name
           value: "$(tasks.setup.results.app-name)"
-    - name: hadolint
+    - name: dockerfile-lint
       taskRef:
-        name: ibm-hadolint
+        name: ibm-dockerfile-lint
       runAfter:
         - test
       params:
@@ -62,7 +62,7 @@ spec:
       taskRef:
         name: ibm-build-tag-push
       runAfter:
-        - hadolint
+        - dockerfile-lint
       params:
         - name: git-url
           value: "$(tasks.setup.results.git-url)"

--- a/pipelines/java-gradle-pipeline.yaml
+++ b/pipelines/java-gradle-pipeline.yaml
@@ -50,9 +50,9 @@ spec:
           value: "$(tasks.setup.results.source-dir)"
         - name: app-name
           value: "$(tasks.setup.results.app-name)"
-    - name: hadolint
+    - name: dockerfile-lint
       taskRef:
-        name: ibm-hadolint
+        name: ibm-dockerfile-lint
       runAfter:
         - test
       params:
@@ -68,7 +68,7 @@ spec:
       taskRef:
         name: ibm-build-tag-push
       runAfter:
-        - hadolint
+        - dockerfile-lint
       params:
         - name: git-url
           value: "$(tasks.setup.results.git-url)"

--- a/pipelines/java-maven-pipeline.yaml
+++ b/pipelines/java-maven-pipeline.yaml
@@ -46,9 +46,9 @@ spec:
         - name: app-name
           value: "$(tasks.setup.results.app-name)"
 
-    - name: hadolint
+    - name: dockerfile-lint
       taskRef:
-        name: ibm-hadolint
+        name: ibm-dockerfile-lint
       runAfter:
         - test
       params:
@@ -65,7 +65,7 @@ spec:
       taskRef:
         name: ibm-build-tag-push
       runAfter:
-        - hadolint
+        - dockerfile-lint
       params:
         - name: git-url
           value: "$(tasks.setup.results.git-url)"

--- a/pipelines/nodejs-pipeline.yaml
+++ b/pipelines/nodejs-pipeline.yaml
@@ -46,9 +46,9 @@ spec:
           value: "$(tasks.setup.results.js-image)"
         - name: app-name
           value: $(tasks.setup.results.app-name)
-    - name: hadolint
+    - name: dockerfile-lint
       taskRef:
-        name: ibm-hadolint
+        name: ibm-dockerfile-lint
       runAfter:
         - test
       params:
@@ -64,7 +64,7 @@ spec:
       taskRef:
         name: ibm-build-tag-push
       runAfter:
-        - hadolint
+        - dockerfile-lint
       params:
         - name: git-url
           value: "$(tasks.setup.results.git-url)"

--- a/tasks/2-lint-dockerfile.yaml
+++ b/tasks/2-lint-dockerfile.yaml
@@ -1,7 +1,7 @@
 apiVersion: tekton.dev/v1beta1
 kind: Task
 metadata:
-  name: ibm-hadolint
+  name: ibm-dockerfile-lint
   annotations:
     description: Optional linter for Dockerfiles; if a ".hadolint" file is in the repo root, this task automatically picks up; otherwise hadolint file name must be passed via ConfigMap. See Hadolint on Dockerhub for more
     app.openshift.io/description: Optional linter for Dockerfiles; if a ".hadolint" file is in the repo root, this task automatically picks up; otherwise hadolint file name must be passed via ConfigMap
@@ -21,7 +21,7 @@ spec:
     - name: CONTEXT
       default: .
     - name: LINT_IMAGE
-      default: hadolint/hadolint
+      default: ghcr.io/hadolint/hadolint:v2.3.0-alpine
     - name: lint-dockerfile
       default: "true"
 
@@ -70,7 +70,6 @@ spec:
               key: HADOLINT_CFG
               optional: true
       script: | 
-        set +x
         PERFORM_LINT="$(params.lint-dockerfile)"
         if [[ "${PERFORM_LINT}" == "false" ]] || [[ -z "${PERFORM_LINT}" ]]; then
           echo "User selected to skip Dockerfile linting. Skipping this task."
@@ -98,5 +97,3 @@ spec:
           echo "For more information about hadolint please refer to https://cloudnativetoolkit.dev/"
           hadolint $(params.DOCKERFILE)
         fi
-        
-        set -x


### PR DESCRIPTION
- Use different image for hadolint that provides `/bin/sh`
- Rename hadolint task name to dockerfile-lint