### PR TITLE
add runAsUser to deploy and helm release tasks to fix OCP 4.7 problem

### DIFF
--- a/tasks/4-deploy.yaml
+++ b/tasks/4-deploy.yaml
@@ -45,6 +45,8 @@ spec:
   steps:
     - name: git-clone
       image: quay.io/ibmgaragecloud/alpine-git
+      securityContext:
+        runAsUser: 10000
       env:
         - name: GIT_PASSWORD
           valueFrom:
@@ -71,6 +73,8 @@ spec:
         git checkout $(params.git-revision)
     - name: deploy
       image: $(params.tools-image)
+      securityContext:
+        runAsUser: 10000
       workingDir: $(params.source-dir)
       env:
         - name: TLS_SECRET_NAME

--- a/tasks/9-helm-release.yaml
+++ b/tasks/9-helm-release.yaml
@@ -39,6 +39,8 @@ spec:
   steps:
     - name: git-clone
       image: quay.io/ibmgaragecloud/alpine-git
+      securityContext:
+        runAsUser: 10000
       env:
         - name: GIT_PASSWORD
           valueFrom:
@@ -65,6 +67,8 @@ spec:
         git checkout $(params.git-revision)
     - name: package-helm
       image: $(params.tools-image)
+      securityContext:
+        runAsUser: 10000
       workingDir: $(params.source-dir)
       env:
         - name: TLS_SECRET_NAME


### PR DESCRIPTION
Fixes IBM/ibm-garage-tekton-tasks#135

On ocp 4.6 it looks like a random UID is selected and both steps in the task are ran as the same UID. That is why it currently works.

On ocp 4.7 the git-clone step is running as root and the deploy and package-helm steps are running as user devops as defined in the image: quay.io/ibmgaragecloud/ibmcloud-dev

Signed-off-by: Larry Steck <lsteck@us.ibm.com>