### PR TITLE
make git repo write for other steps to be able to use

### DIFF
--- a/tasks/4-deploy.yaml
+++ b/tasks/4-deploy.yaml
@@ -1,7 +1,7 @@
 apiVersion: tekton.dev/v1beta1
 kind: Task
 metadata:
-  name: ibm-deploy
+  name: ibm-deploy-carlos-test
   annotations:
     description: Deploys the application to the CI environment for verification using the provided helm chart
     app.openshift.io/description: Deploys the application to the CI environment for verification using the provided helm chart
@@ -67,6 +67,8 @@ spec:
             git clone $(params.git-url) $(params.source-dir)
         fi
         set -x
+        # Allowing next steps to have write access to cloned git repo
+        chmod -R a+w $(params.source-dir)
         cd $(params.source-dir)
         git checkout $(params.git-revision)
     - name: deploy

--- a/tasks/4-deploy.yaml
+++ b/tasks/4-deploy.yaml
@@ -1,7 +1,7 @@
 apiVersion: tekton.dev/v1beta1
 kind: Task
 metadata:
-  name: ibm-deploy-carlos-test
+  name: ibm-deploy
   annotations:
     description: Deploys the application to the CI environment for verification using the provided helm chart
     app.openshift.io/description: Deploys the application to the CI environment for verification using the provided helm chart

--- a/tasks/9-helm-release.yaml
+++ b/tasks/9-helm-release.yaml
@@ -61,6 +61,8 @@ spec:
             git clone $(params.git-url) $(params.source-dir)
         fi
         set -x
+        # Allowing next steps to have write access to cloned git repo
+        chmod -R a+w $(params.source-dir)
         cd $(params.source-dir)
         git checkout $(params.git-revision)
     - name: package-helm


### PR DESCRIPTION
In openshift OCP47 the buildah task requires privilege without it can't build the image
```
oc adm policy add-scc-to-user privileged -z pipeline
```

then this would allow containers to run as root(0) the git-clone task uses the alpine image `quay.io/ibmgaragecloud/alpine-git` this image is the one from dockerhub and runs as `root(0)` 
the problem is the next step/container runs as `devops(10001)` user and it doesn't have write access to the files created in `/source`

Fixes #135 
Fixes #131 

