### PR TITLE
adjust trivy scan policy for available fixes

### DIFF
--- a/tasks/3-img-scan-trivy.yaml
+++ b/tasks/3-img-scan-trivy.yaml
@@ -16,6 +16,9 @@ spec:
     - name: scan-image
       description: Flag indicating that a scan should be performed
       default: "false"
+    - name: trivy-ignoreUnfixed
+      description: Flag indicating that Trivy scans should ignore unfixed vulnerabilities 
+      default: "true"
     - name: SKOPEO_IMAGE
       default: quay.io/containers/skopeo:v1.1.0
     - name: IMAGE_FROM_TLS_VERIFY
@@ -83,7 +86,7 @@ spec:
           PATH_TO_IMAGE="/var/oci/image"
           echo -e "Trivy Security Scan image in registry"
           trivy image --exit-code 0 --input ${PATH_TO_IMAGE}
-          trivy image --exit-code 1 --severity CRITICAL --input ${PATH_TO_IMAGE}
+          TRIVY_IGNORE_UNFIXED="$(params.trivy-ignoreUnfixed)" trivy image --exit-code 1 --severity CRITICAL --input ${PATH_TO_IMAGE}
           my_exit_code=$?
           echo "Scan exit code :--- $my_exit_code"
           if [ ${my_exit_code} == 1 ]; then

--- a/tasks/9-img-scan.yaml
+++ b/tasks/9-img-scan.yaml
@@ -89,7 +89,7 @@ spec:
           PATH_TO_IMAGE="/var/oci/image"
           echo -e "Trivy Security Scan image in registry"
           trivy image --exit-code 0 --input ${PATH_TO_IMAGE}
-          trivy image --exit-code 1 --severity CRITICAL --input ${PATH_TO_IMAGE}
+          trivy image --exit-code 1 --severity CRITICAL --ignore-unfixed --input ${PATH_TO_IMAGE}
           my_exit_code=$?
           echo "Scan exit code :--- $my_exit_code"
           if [ ${my_exit_code} == 1 ]; then

--- a/tasks/9-img-scan.yaml
+++ b/tasks/9-img-scan.yaml
@@ -16,6 +16,9 @@ spec:
     - name: scan-trivy
       description: Flag indicating that a scan should be performed with Trivy
       default: "false"
+    - name: trivy-ignoreUnfixed
+      description: Flag indicating that Trivy scans should ignore unfixed vulnerabilities 
+      default: "true"
     - name: scan-ibm
       description: Flag indicating that a scan should be performed with IBM VA
       default: "false"
@@ -89,7 +92,7 @@ spec:
           PATH_TO_IMAGE="/var/oci/image"
           echo -e "Trivy Security Scan image in registry"
           trivy image --exit-code 0 --input ${PATH_TO_IMAGE}
-          trivy image --exit-code 1 --severity CRITICAL --ignore-unfixed --input ${PATH_TO_IMAGE}
+          TRIVY_IGNORE_UNFIXED="$(params.trivy-ignoreUnfixed)" trivy image --exit-code 1 --severity CRITICAL --input ${PATH_TO_IMAGE}
           my_exit_code=$?
           echo "Scan exit code :--- $my_exit_code"
           if [ ${my_exit_code} == 1 ]; then


### PR DESCRIPTION
Change the image scan with trivy that can block a pipeline to only consider fixes that are available. 

Resolves issues with UBI images failing on CVE-2019-1010022. Retains first pass which reports all vulnerabilities and only changes the second pass for `CRITICAL` vulnerabilities.