### PR TITLE
Updates for signed image setup script

### DIFF
--- a/utilities/setup-image-signing-keys.sh
+++ b/utilities/setup-image-signing-keys.sh
@@ -44,7 +44,7 @@ echo "You will be prompted for additional input..."
 printf "\n\n"
 
 
-output=$(gpg --generate-key)
+output=$(gpg --default-new-key-algo rsa4096 --generate-key)
 printf "\n-----\n${output}\n-----\n\n"
 
 KEY_FINGERPRINT=$(echo "${output}" | sed -n '2p' | tr -d ' ')

--- a/utilities/setup-image-signing-keys.sh
+++ b/utilities/setup-image-signing-keys.sh
@@ -167,10 +167,10 @@ type: Opaque
 metadata:
   name: portieris-keys
 data:
-  vault-url: "$(echo $VAULT_URL | base64)"
-  vault-instance-id: "$(echo $VAULT_INSTANCE_ID | base64)"
-  vault-key-id: "$(echo $VAULT_PRIVATE_KEY_ID | base64)"
-  portieris-signature-fingerprint: "$(echo $KEY_FINGERPRINT | base64)"
+  vault-url: "$(echo -n $VAULT_URL | base64)"
+  vault-instance-id: "$(echo -n $VAULT_INSTANCE_ID | base64)"
+  vault-key-id: "$(echo -n $VAULT_PRIVATE_KEY_ID | base64)"
+  portieris-signature-fingerprint: "$(echo -n $KEY_FINGERPRINT | base64)"
   
 EOL
 oc apply -f portieris-secrets.yml


### PR DESCRIPTION
Fixes: 

-  img-release tekton task crashing during retrieval of private key from KMS (Key Protect/HPCS) URL due to extra linefeed stored in `portieris-keys` secret for the `VAULT_URL` key.
- gpg may default to a algorithm on some platforms to `EdDSA` which results in a `openpgp: unsupported feature: public key type: 22` error with [portieris](https://github.com/IBM/portieris)