### PR TITLE
faciliate .trivyignore from git and add to nodejs pipeline

### DIFF
--- a/pipelines/nodejs-pipeline.yaml
+++ b/pipelines/nodejs-pipeline.yaml
@@ -166,6 +166,12 @@ spec:
           value: $(tasks.setup.results.scan-trivy)
         - name: scan-ibm
           value: $(tasks.setup.results.scan-ibm)
+        - name: GIT_URL
+          value: $(tasks.setup.results.git-url)
+        - name: GIT_REVISION
+          value: $(tasks.setup.results.git-revision)
+        - name: source-dir
+          value: $(tasks.setup.results.source-dir)
     - name: helm-release
       taskRef:
         name: ibm-helm-release

--- a/tasks/3-img-scan-trivy.yaml
+++ b/tasks/3-img-scan-trivy.yaml
@@ -11,6 +11,18 @@ metadata:
     version: 0.0.0
 spec:
   params:
+    - name: GIT_URL
+      default: ''
+      description: >-
+        URL of git repo, if provided it allows .trivyignore to be used from
+        project source when running scan
+      type: string
+    - name: GIT_REVISION
+      default: master
+      type: string
+    - default: /source
+      name: source-dir
+      type: string
     - name: image-url
       description: "The location of image to scan on IBM Container Registry <server>/<namespace>/<repository>:<tag>"
     - name: scan-image
@@ -28,7 +40,48 @@ spec:
   volumes:
     - name: oci-image
       emptyDir: {}
+    - name: source
+      emptyDir: {}
+  stepTemplate:
+    name: ''
+    resources: {}
+    volumeMounts:
+      - mountPath: $(params.source-dir)
+        name: source
   steps:
+    - name: git-clone
+      image: quay.io/ibmgaragecloud/alpine-git
+      env:
+        - name: GIT_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: password
+              name: git-credentials
+              optional: true
+        - name: GIT_USERNAME
+          valueFrom:
+            secretKeyRef:
+              key: username
+              name: git-credentials
+              optional: true
+      resources: {}
+      script: |
+        set +x
+
+        if [ -z $(params.GIT_URL) ]; then
+            echo "No git URL provided, skipping clone"
+            exit 0
+        fi
+
+        if [[ -n "${GIT_USERNAME}" ]] && [[ -n "${GIT_PASSWORD}" ]]; then
+            git clone "$(echo $(params.GIT_URL) | awk -F '://' '{print $1}')://${GIT_USERNAME}:${GIT_PASSWORD}@$(echo $(params.GIT_URL) | awk -F '://' '{print $2}')" $(params.source-dir)
+        else
+            set -x
+            git clone $(params.GIT_URL) $(params.source-dir)
+        fi
+        set -x
+        cd $(params.source-dir)
+        git checkout $(params.GIT_REVISION)
     - name: pull-image
       image: $(params.SKOPEO_IMAGE)
       env:
@@ -47,6 +100,7 @@ spec:
       volumeMounts:
         - mountPath: /var/oci
           name: oci-image
+      workingDir: $(params.source-dir)
       securityContext:
         privileged: true
       script: |
@@ -76,6 +130,7 @@ spec:
       volumeMounts:
         - mountPath: /var/oci
           name: oci-image
+      workingDir: $(params.source-dir)
       script: |
           set -e
           PERFORM_SCAN="$(params.scan-image)"

--- a/tasks/9-img-scan.yaml
+++ b/tasks/9-img-scan.yaml
@@ -11,6 +11,18 @@ metadata:
     version: 0.0.0
 spec:
   params:
+    - name: GIT_URL
+      default: ''
+      description: >-
+        URL of git repo, if provided it allows .trivyignore to be used from
+        project source when running scan
+      type: string
+    - name: GIT_REVISION
+      default: master
+      type: string
+    - default: /source
+      name: source-dir
+      type: string
     - name: image-url
       description: "The location of image to scan on IBM Container Registry <server>/<namespace>/<repository>:<tag>"
     - name: scan-trivy
@@ -33,7 +45,48 @@ spec:
   volumes:
     - name: oci-image
       emptyDir: {}
+    - name: source
+      emptyDir: {}
+  stepTemplate:
+    name: ''
+    resources: {}
+    volumeMounts:
+      - mountPath: $(params.source-dir)
+        name: source
   steps:
+    - name: git-clone
+      image: quay.io/ibmgaragecloud/alpine-git
+      env:
+        - name: GIT_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: password
+              name: git-credentials
+              optional: true
+        - name: GIT_USERNAME
+          valueFrom:
+            secretKeyRef:
+              key: username
+              name: git-credentials
+              optional: true
+      resources: {}
+      script: |
+        set +x
+
+        if [ -z $(params.GIT_URL) ]; then
+            echo "No git URL provided, skipping clone"
+            exit 0
+        fi
+
+        if [[ -n "${GIT_USERNAME}" ]] && [[ -n "${GIT_PASSWORD}" ]]; then
+            git clone "$(echo $(params.GIT_URL) | awk -F '://' '{print $1}')://${GIT_USERNAME}:${GIT_PASSWORD}@$(echo $(params.GIT_URL) | awk -F '://' '{print $2}')" $(params.source-dir)
+        else
+            set -x
+            git clone $(params.GIT_URL) $(params.source-dir)
+        fi
+        set -x
+        cd $(params.source-dir)
+        git checkout $(params.GIT_REVISION)
     - name: trivy-pull
       image: $(params.SKOPEO_IMAGE)
       env:
@@ -52,6 +105,7 @@ spec:
       volumeMounts:
         - mountPath: /var/oci
           name: oci-image
+      workingDir: $(params.source-dir)
       securityContext:
         privileged: true
       script: |
@@ -82,6 +136,7 @@ spec:
       volumeMounts:
         - mountPath: /var/oci
           name: oci-image
+      workingDir: $(params.source-dir)
       script: |
           set -ex
           PERFORM_SCAN="$(params.scan-trivy)"


### PR DESCRIPTION
Signed-off-by: Brian Innes <binnes@uk.ibm.com>

Trivy uses a .trivyignore file to allow CVEs to be explicitly ignored.  The --ignoreunfixed flag tells Trivy to ignore all unfixed CVEs in a distro, but not all distros provide unfixed data and sometimes it is preferable to explicitly specify CVEs you want to ignore
This pull request adds the option to provide a git URL and revision as the source of the .trivyignore file, which could be the source for the container, or a company wide config repo.  If the Git URL is not provided then the tasks work as before.
The nodejs pipeline has also been altered to provide the project git URL to the trivy scan task, so is a .trivyignore file is in the root of the project, then it will be used in the scan
This addresses https://github.com/cloud-native-toolkit/planning/issues/876