### PR TITLE
Updates tasks to run without privileged security constraint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 local/
 node_modules/
 dist/
+.idea/

--- a/bin/package-yaml.sh
+++ b/bin/package-yaml.sh
@@ -16,6 +16,8 @@ mkdir -p "${DIST_DIR}"
 
 RESOURCE_YAML="${DIST_DIR}/release.yaml"
 
+echo "Publishing ${VERSION_NUMBER} package to ${RESOURCE_YAML}"
+
 echo -n "" > "${RESOURCE_YAML}"
 
 # remove leading 'v', if present

--- a/tasks/2-build-tag-push-ace-bar.yaml
+++ b/tasks/2-build-tag-push-ace-bar.yaml
@@ -11,127 +11,181 @@ metadata:
     version: 0.0.0
 spec:
   params:
-  - name: git-url
-  - name: git-revision
-    default: master
-  - name: source-dir
-    default: /source
-  - name: image-server
-    default: ""
-  - name: image-namespace
-    default: ""
-  - name: image-repository
-    default: ""
-  - name: image-tag
-    default: ""
-  - name: BUILDER_IMAGE
-    default: quay.io/buildah/stable:v1.15.0
-  - name: DOCKERFILE
-    default: ./Dockerfile
-  - name: CONTEXT
-    default: .
-  - name: TLSVERIFY
-    default: "false"
-  - name: FORMAT
-    default: docker
-  - name: STORAGE_DRIVER
-    description: Set buildah storage driver
-    default: overlay
-  - name: app-name
-    default: ""
-  - name: ace-project
-    default: ""
+    - name: git-url
+    - name: git-revision
+      default: master
+    - name: source-dir
+      default: /source
+    - name: image-server
+      default: ""
+    - name: image-namespace
+      default: ""
+    - name: image-repository
+      default: ""
+    - name: image-tag
+      default: ""
+    - name: BUILDER_IMAGE
+      default: registry.redhat.io/rhel8/buildah@sha256:23fb7971ea6ac4aaaaa1139473a602df0df19222a3b5a76b551b2b9ddd92e927
+    - name: DOCKERFILE
+      default: ./Dockerfile
+    - name: CONTEXT
+      default: .
+    - name: TLSVERIFY
+      default: "false"
+    - name: FORMAT
+      default: docker
+    - name: STORAGE_DRIVER
+      description: Set buildah storage driver
+      default: vfs
+    - name: app-name
+      default: ""
+    - name: ace-project
+      default: ""
   volumes:
-  - name: varlibcontainers
-    emptyDir: {}
-  - name: source
-    emptyDir: {}
+    - name: varlibcontainers
+      emptyDir: {}
+    - name: source
+      emptyDir: {}
   stepTemplate:
     volumeMounts:
-    - name: source
-      mountPath: $(params.source-dir)
+      - name: source
+        mountPath: $(params.source-dir)
   steps:
-  - name: git-clone
-    image: quay.io/ibmgaragecloud/alpine-git
-    env:
-    - name: GIT_PASSWORD
-      valueFrom:
-        secretKeyRef:
-          key: password
-          name: git-credentials
-          optional: true
-    - name: GIT_USERNAME
-      valueFrom:
-        secretKeyRef:
-          key: username
-          name: git-credentials
-          optional: true
-    script: |
-      set +x
-      if [[ -n "${GIT_USERNAME}" ]] && [[ -n "${GIT_PASSWORD}" ]]; then
-          git clone "$(echo $(params.git-url) | awk -F '://' '{print $1}')://${GIT_USERNAME}:${GIT_PASSWORD}@$(echo $(params.git-url) | awk -F '://' '{print $2}')" $(params.source-dir)
-      else
-          set -x
-          git clone $(params.git-url) $(params.source-dir)
-      fi
-      set -x
-      cd $(params.source-dir)
-      git checkout $(params.git-revision)
-  - name: compile
-    image: docker.io/rsundara/ace-build
-    envFrom:
-    - secretRef:
-        name: artifactory-access
-    command:
-    - /bin/sh
-    args:
-    - -c
-    - |
-      set -eu;
-      echo "Compile BAR";
+    - name: setup-docker-auth
+      image: $(params.BUILDER_IMAGE)
+      workingDir: $(params.source-dir)
+      env:
+        - name: REGISTRY_USER
+          valueFrom:
+            secretKeyRef:
+              name: registry-access
+              key: REGISTRY_USER
+              optional: true
+        - name: REGISTRY_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: registry-access
+              key: REGISTRY_PASSWORD
+              optional: true
+        - name: AUTH_CONFIG
+          valueFrom:
+            secretKeyRef:
+              name: registry-auth
+              key: .dockerconfigjson
+              optional: true
+        - name: AUTH_CONFIG_OVERRIDE
+          valueFrom:
+            secretKeyRef:
+              name: registry-auth-local
+              key: .dockerconfigjson
+              optional: true
+        - name: IBM_ENTITLED_REGISTRY_USER
+          valueFrom:
+            secretKeyRef:
+              name: ibm-entitled-registry-credentials
+              key: IBM_ENTITLED_REGISTRY_USER
+              optional: true
+        - name: IBM_ENTITLED_REGISTRY_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: ibm-entitled-registry-credentials
+              key: IBM_ENTITLED_REGISTRY_PASSWORD
+              optional: true
+      volumeMounts:
+        - mountPath: /var/lib/containers
+          name: varlibcontainers
+      script: |
+        if [[ -n "${AUTH_CONFIG_OVERRIDE}" ]]; then
+          AUTH_CONFIG="${AUTH_CONFIG_OVERRIDE}"
+        elif [[ -z "${AUTH_CONFIG}" ]]; then
+          AUTH_CONFIG="{}"
+        fi
+        
+        AUTH_FILE="/var/lib/containers/auth.json"
+        
+        echo "${AUTH_CONFIG}" > "${AUTH_FILE}"
+        
+        if [[ -n "${IBM_ENTITLED_REGISTRY_USER}" ]] && [[ -n "${IBM_ENTITLED_REGISTRY_PASSWORD}" ]]; then
+          buildah login --authfile "${AUTH_FILE}" -u ${IBM_ENTITLED_REGISTRY_USER} -p ${IBM_ENTITLED_REGISTRY_PASSWORD} cp.icr.io
+          echo "buildah login --authfile \"${AUTH_FILE}\" -u \"${IBM_ENTITLED_REGISTRY_USER}\" -p \"xxxxx\" cp.icr.io"
+        fi
+        
+        if [[ -n "${REGISTRY_USER}" ]] && [[ -n "${REGISTRY_PASSWORD}" ]] && [[ "$(params.image-server)" != "image-registry.openshift-image-registry.svc:5000"  ]]; then
+          buildah login --authfile "${AUTH_FILE}" -u "${REGISTRY_USER}" -p "${REGISTRY_PASSWORD}" "$(params.image-server)"
+          echo "buildah login --authfile \"${AUTH_FILE}\" -u \"${REGISTRY_USER}\" -p \"xxxxx\" \"$(params.image-server)\""
+        fi
+        
+        echo "Auth file: ${AUTH_FILE}"
+    - name: git-clone
+      image: quay.io/ibmgaragecloud/alpine-git
+      env:
+        - name: GIT_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: git-credentials
+              key: password
+              optional: true
+        - name: GIT_USERNAME
+          valueFrom:
+            secretKeyRef:
+              name: git-credentials
+              key: username
+              optional: true
+      script: |
+        set +x
+        if [[ -n "${GIT_USERNAME}" ]] && [[ -n "${GIT_PASSWORD}" ]]; then
+            git clone "$(echo $(params.git-url) | awk -F '://' '{print $1}')://${GIT_USERNAME}:${GIT_PASSWORD}@$(echo $(params.git-url) | awk -F '://' '{print $2}')" $(params.source-dir)
+        else
+            set -x
+            git clone $(params.git-url) $(params.source-dir)
+        fi
+        set -x
+        cd $(params.source-dir)
+        git checkout $(params.git-revision)
+    - name: compile
+      image: docker.io/rsundara/ace-build
+      envFrom:
+        - secretRef:
+            name: artifactory-access
+      command:
+        - /bin/sh
+      args:
+        - -c
+        - |
+          set -eu;
+          echo "Compile BAR";
+    
+          # Used for debugging with mqsicreatebar
+          /usr/bin/Xvfb :100 &
+          export DISPLAY=:100
+    
+          cd $(params.source-dir)/workspace
+          echo "Generating BAR"
+          mqsicreatebar -data . -b $(params.source-dir)/$(params.app-name)-$(params.image-tag).bar -a $(params.ace-project)
+    
+          echo "Upload BAR to Artifactory"
+          curl -u ${ARTIFACTORY_USER}:${ARTIFACTORY_ENCRYPT} -T $(params.source-dir)/$(params.app-name)-$(params.image-tag).bar "$(ARTIFACTORY_URL)/artifactory/generic-local/$(params.app-name)-$(params.image-tag).bar"
+    - name: build
+      image: $(params.BUILDER_IMAGE)
+      workingDir: $(params.source-dir)
+      volumeMounts:
+        - mountPath: /var/lib/containers
+          name: varlibcontainers
+      script: |
+        APP_IMAGE="$(params.image-server)/$(params.image-namespace)/$(params.image-repository):$(params.image-tag)"
+        
+        AUTH_FILE="/var/lib/containers/auth.json"
+        echo "Auth file: ${AUTH_FILE}"
+        
+        set -x
+        
+        buildah --storage-driver=$(params.STORAGE_DRIVER) bud \
+          --authfile "${AUTH_FILE}" \
+          --format=$(params.FORMAT) --tls-verify=$(params.TLSVERIFY) \
+          --no-cache -f $(params.DOCKERFILE) -t ${APP_IMAGE} $(params.CONTEXT)
 
-      # Used for debugging with mqsicreatebar
-      /usr/bin/Xvfb :100 &
-      export DISPLAY=:100
-
-      cd $(params.source-dir)/workspace
-      echo "Generating BAR"
-      mqsicreatebar -data . -b $(params.source-dir)/$(params.app-name)-$(params.image-tag).bar -a $(params.ace-project)
-
-      echo "Upload BAR to Artifactory"
-      curl -u ${ARTIFACTORY_USER}:${ARTIFACTORY_ENCRYPT} -T $(params.source-dir)/$(params.app-name)-$(params.image-tag).bar "$(ARTIFACTORY_URL)/artifactory/generic-local/$(params.app-name)-$(params.image-tag).bar"
-  - name: build
-    image: $(params.BUILDER_IMAGE)
-    workingDir: $(params.source-dir)
-    env:
-    - name: REGISTRY_USER
-      valueFrom:
-        secretKeyRef:
-          key: REGISTRY_USER
-          name: registry-access
-          optional: true
-    - name: REGISTRY_PASSWORD
-      valueFrom:
-        secretKeyRef:
-          key: REGISTRY_PASSWORD
-          name: registry-access
-          optional: true
-    envFrom:
-    - secretRef:
-        name: ibm-entitled-registry-credentials
-    volumeMounts:
-    - mountPath: /var/lib/containers
-      name: varlibcontainers
-    securityContext:
-      privileged: true
-    script: |
-      APP_IMAGE="$(params.image-server)/$(params.image-namespace)/$(params.image-repository):$(params.image-tag)"
-      buildah login -u ${IBM_ENTITLED_REGISTRY_USER} -p ${IBM_ENTITLED_REGISTRY_PASSWORD} cp.icr.io
-      buildah --layers --storage-driver=$(params.STORAGE_DRIVER) bud --format=$(params.FORMAT) --tls-verify=$(params.TLSVERIFY) -f $(params.DOCKERFILE) -t ${APP_IMAGE} $(params.CONTEXT)
-      set +x
-      if [[ -n "${REGISTRY_USER}" ]] && [[ -n "${REGISTRY_PASSWORD}" ]] && [[ "$(params.image-server)" != "image-registry.openshift-image-registry.svc:5000"  ]]; then
-        buildah login -u "${REGISTRY_USER}" -p "${REGISTRY_PASSWORD}" "$(params.image-server)"
-        echo "buildah login -u "${REGISTRY_USER}" -p "xxxxx" "$(params.image-server)""
-      fi
-      set -x
-      buildah --storage-driver=$(params.STORAGE_DRIVER) push --tls-verify=$(params.TLSVERIFY) --digestfile ./image-digest ${APP_IMAGE} docker://${APP_IMAGE}
+        buildah --storage-driver=$(params.STORAGE_DRIVER) push \
+          --authfile "${AUTH_FILE}" \
+          --tls-verify=$(params.TLSVERIFY) \
+          --digestfile ./image-digest \
+          ${APP_IMAGE} docker://${APP_IMAGE}

--- a/tasks/2-build-tag-push.yaml
+++ b/tasks/2-build-tag-push.yaml
@@ -25,7 +25,7 @@ spec:
     - name: image-tag
       default: ""
     - name: BUILDER_IMAGE
-      default: quay.io/buildah/stable:v1.15.0
+      default: registry.redhat.io/rhel8/buildah@sha256:23fb7971ea6ac4aaaaa1139473a602df0df19222a3b5a76b551b2b9ddd92e927
     - name: DOCKERFILE
       default: ./Dockerfile
     - name: CONTEXT
@@ -33,10 +33,10 @@ spec:
     - name: TLSVERIFY
       default: "false"
     - name: FORMAT
-      default: "docker"
+      default: docker
     - name: STORAGE_DRIVER
       description: Set buildah storage driver
-      default: overlay
+      default: vfs
   volumes:
     - name: varlibcontainers
       emptyDir: {}
@@ -47,6 +47,70 @@ spec:
       - name: source
         mountPath: $(params.source-dir)
   steps:
+    - name: setup-docker-auth
+      image: $(params.BUILDER_IMAGE)
+      env:
+        - name: REGISTRY_USER
+          valueFrom:
+            secretKeyRef:
+              name: registry-access
+              key: REGISTRY_USER
+              optional: true
+        - name: REGISTRY_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: registry-access
+              key: REGISTRY_PASSWORD
+              optional: true
+        - name: AUTH_CONFIG
+          valueFrom:
+            secretKeyRef:
+              name: registry-auth
+              key: .dockerconfigjson
+              optional: true
+        - name: AUTH_CONFIG_OVERRIDE
+          valueFrom:
+            secretKeyRef:
+              name: registry-auth-local
+              key: .dockerconfigjson
+              optional: true
+        - name: IBM_ENTITLED_REGISTRY_USER
+          valueFrom:
+            secretKeyRef:
+              name: ibm-entitled-registry-credentials
+              key: IBM_ENTITLED_REGISTRY_USER
+              optional: true
+        - name: IBM_ENTITLED_REGISTRY_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: ibm-entitled-registry-credentials
+              key: IBM_ENTITLED_REGISTRY_PASSWORD
+              optional: true
+      volumeMounts:
+        - mountPath: /var/lib/containers
+          name: varlibcontainers
+      script: |
+        if [[ -n "${AUTH_CONFIG_OVERRIDE}" ]]; then
+          AUTH_CONFIG="${AUTH_CONFIG_OVERRIDE}"
+        elif [[ -z "${AUTH_CONFIG}" ]]; then
+          AUTH_CONFIG="{}"
+        fi
+        
+        AUTH_FILE="/var/lib/containers/auth.json"
+        
+        echo "${AUTH_CONFIG}" > "${AUTH_FILE}"
+        
+        if [[ -n "${IBM_ENTITLED_REGISTRY_USER}" ]] && [[ -n "${IBM_ENTITLED_REGISTRY_PASSWORD}" ]]; then
+          buildah login --authfile "${AUTH_FILE}" -u ${IBM_ENTITLED_REGISTRY_USER} -p ${IBM_ENTITLED_REGISTRY_PASSWORD} cp.icr.io
+          echo "buildah login --authfile \"${AUTH_FILE}\" -u \"${IBM_ENTITLED_REGISTRY_USER}\" -p \"xxxxx\" cp.icr.io"
+        fi
+        
+        if [[ -n "${REGISTRY_USER}" ]] && [[ -n "${REGISTRY_PASSWORD}" ]] && [[ "$(params.image-server)" != "image-registry.openshift-image-registry.svc:5000"  ]]; then
+          buildah login --authfile "${AUTH_FILE}" -u "${REGISTRY_USER}" -p "${REGISTRY_PASSWORD}" "$(params.image-server)"
+          echo "buildah login --authfile \"${AUTH_FILE}\" -u \"${REGISTRY_USER}\" -p \"xxxxx\" \"$(params.image-server)\""
+        fi
+        
+        echo "Auth file: ${AUTH_FILE}"
     - name: git-clone
       image: quay.io/ibmgaragecloud/alpine-git
       env:
@@ -76,48 +140,24 @@ spec:
     - name: build
       image: $(params.BUILDER_IMAGE)
       workingDir: $(params.source-dir)
-      env:
-        - name: REGISTRY_USER
-          valueFrom:
-            secretKeyRef:
-              name: registry-access
-              key: REGISTRY_USER
-              optional: true
-        - name: REGISTRY_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: registry-access
-              key: REGISTRY_PASSWORD
-              optional: true
-        - name: IBM_ENTITLED_REGISTRY_USER
-          valueFrom:
-            secretKeyRef:
-              name: ibm-entitled-registry-credentials
-              key: IBM_ENTITLED_REGISTRY_USER
-              optional: true
-        - name: IBM_ENTITLED_REGISTRY_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: ibm-entitled-registry-credentials
-              key: IBM_ENTITLED_REGISTRY_PASSWORD
-              optional: true
       volumeMounts:
         - mountPath: /var/lib/containers
           name: varlibcontainers
-      securityContext:
-        privileged: true
       script: |
         APP_IMAGE="$(params.image-server)/$(params.image-namespace)/$(params.image-repository):$(params.image-tag)"
-        if [[ -n "${IBM_ENTITLED_REGISTRY_USER}" ]] && [[ -n "${IBM_ENTITLED_REGISTRY_PASSWORD}" ]]; then
-          buildah login -u ${IBM_ENTITLED_REGISTRY_USER} -p ${IBM_ENTITLED_REGISTRY_PASSWORD} cp.icr.io
-          echo "buildah login -u \"${IBM_ENTITLED_REGISTRY_USER}\" -p \"xxxxx\" cp.icr.io"
-        fi
-        buildah --layers --storage-driver=$(params.STORAGE_DRIVER) bud --format=$(params.FORMAT) --tls-verify=$(params.TLSVERIFY) -f $(params.DOCKERFILE) -t ${APP_IMAGE} $(params.CONTEXT)
-        set +x
-        if [[ -n "${REGISTRY_USER}" ]] && [[ -n "${REGISTRY_PASSWORD}" ]] && [[ "$(params.image-server)" != "image-registry.openshift-image-registry.svc:5000"  ]]; then
-          buildah login -u "${REGISTRY_USER}" -p "${REGISTRY_PASSWORD}" "$(params.image-server)"
-          echo "buildah login -u \"${REGISTRY_USER}\" -p \"xxxxx\" \"$(params.image-server)\""
-        fi
-
+        
+        AUTH_FILE="/var/lib/containers/auth.json"
+        echo "Auth file: ${AUTH_FILE}"
+        
         set -x
-        buildah --storage-driver=$(params.STORAGE_DRIVER) push --tls-verify=$(params.TLSVERIFY) --digestfile ./image-digest ${APP_IMAGE} docker://${APP_IMAGE}
+        
+        buildah --storage-driver=$(params.STORAGE_DRIVER) bud \
+          --authfile "${AUTH_FILE}" \
+          --format=$(params.FORMAT) --tls-verify=$(params.TLSVERIFY) \
+          --no-cache -f $(params.DOCKERFILE) -t ${APP_IMAGE} $(params.CONTEXT)
+
+        buildah --storage-driver=$(params.STORAGE_DRIVER) push \
+          --authfile "${AUTH_FILE}" \
+          --tls-verify=$(params.TLSVERIFY) \
+          --digestfile ./image-digest \
+          ${APP_IMAGE} docker://${APP_IMAGE}

--- a/tasks/6-operator-bundle.yaml
+++ b/tasks/6-operator-bundle.yaml
@@ -27,7 +27,7 @@ spec:
     - name: BUNDLE_IMAGE
       default: quay.io/ibmgaragecloud/operator-sdk:v0.10.4
     - name: BUILDER_IMAGE
-      default: quay.io/buildah/stable:v1.15.0
+      default: registry.redhat.io/rhel8/buildah@sha256:23fb7971ea6ac4aaaaa1139473a602df0df19222a3b5a76b551b2b9ddd92e927
     - name: DOCKERFILE
       default: ./bundle.Dockerfile
     - name: CONTEXT
@@ -38,7 +38,7 @@ spec:
       default: "docker"
     - name: STORAGE_DRIVER
       description: Set buildah storage driver
-      default: overlay
+      default: vfs
   results:
     - name: bundle-image-url
   volumes:
@@ -51,6 +51,73 @@ spec:
       - name: source
         mountPath: $(params.source-dir)
   steps:
+    - name: setup-docker-auth
+      image: $(params.BUILDER_IMAGE)
+      env:
+        - name: REGISTRY_USER
+          valueFrom:
+            secretKeyRef:
+              name: registry-access
+              key: REGISTRY_USER
+              optional: true
+        - name: REGISTRY_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: registry-access
+              key: REGISTRY_PASSWORD
+              optional: true
+        - name: AUTH_CONFIG
+          valueFrom:
+            secretKeyRef:
+              name: registry-auth
+              key: .dockerconfigjson
+              optional: true
+        - name: AUTH_CONFIG_OVERRIDE
+          valueFrom:
+            secretKeyRef:
+              name: registry-auth-local
+              key: .dockerconfigjson
+              optional: true
+        - name: IBM_ENTITLED_REGISTRY_USER
+          valueFrom:
+            secretKeyRef:
+              name: ibm-entitled-registry-credentials
+              key: IBM_ENTITLED_REGISTRY_USER
+              optional: true
+        - name: IBM_ENTITLED_REGISTRY_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: ibm-entitled-registry-credentials
+              key: IBM_ENTITLED_REGISTRY_PASSWORD
+              optional: true
+      volumeMounts:
+        - mountPath: /var/lib/containers
+          name: varlibcontainers
+      script: |
+        if [[ -n "${AUTH_CONFIG_OVERRIDE}" ]]; then
+          AUTH_CONFIG="${AUTH_CONFIG_OVERRIDE}"
+        elif [[ -z "${AUTH_CONFIG}" ]]; then
+          AUTH_CONFIG="{}"
+        fi
+        
+        AUTH_FILE="/var/lib/containers/auth.json"
+        
+        echo "${AUTH_CONFIG}" > "${AUTH_FILE}"
+        
+        if [[ -n "${IBM_ENTITLED_REGISTRY_USER}" ]] && [[ -n "${IBM_ENTITLED_REGISTRY_PASSWORD}" ]]; then
+          buildah login --authfile "${AUTH_FILE}" -u ${IBM_ENTITLED_REGISTRY_USER} -p ${IBM_ENTITLED_REGISTRY_PASSWORD} cp.icr.io
+          echo "buildah login --authfile \"${AUTH_FILE}\" -u \"${IBM_ENTITLED_REGISTRY_USER}\" -p \"xxxxx\" cp.icr.io"
+        fi
+        
+        IMAGE_URL="$(params.image-url)"
+        REGISTRY_SERVER=$(echo "${IMAGE_URL}" | awk -F / '{print $1}')
+        
+        if [[ -n "${REGISTRY_USER}" ]] && [[ -n "${REGISTRY_PASSWORD}" ]] && [[ "${REGISTRY_SERVER}" != "image-registry.openshift-image-registry.svc:5000"  ]]; then
+          buildah login --authfile "${AUTH_FILE}" -u "${REGISTRY_USER}" -p "${REGISTRY_PASSWORD}" "${REGISTRY_SERVER}"
+          echo "buildah login --authfile \"${AUTH_FILE}\" -u \"${REGISTRY_USER}\" -p \"xxxxx\" \"${REGISTRY_SERVER}\""
+        fi
+        
+        echo "Auth file: ${AUTH_FILE}"
     - name: git-clone
       image: quay.io/ibmgaragecloud/alpine-git
       env:
@@ -80,25 +147,13 @@ spec:
     - name: build
       image: $(params.BUNDLE_IMAGE)
       workingDir: $(params.source-dir)
-      env:
-        - name: REGISTRY_USER
-          valueFrom:
-            secretKeyRef:
-              name: registry-access
-              key: REGISTRY_USER
-              optional: true
-        - name: REGISTRY_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: registry-access
-              key: REGISTRY_PASSWORD
-              optional: true
       volumeMounts:
         - mountPath: /var/lib/containers
           name: varlibcontainers
-      securityContext:
-        privileged: true
       script: |
+        AUTH_FILE="/var/lib/containers/auth.json"
+        echo "Auth file: ${AUTH_FILE}"
+        
         export VERSION="$(params.image-tag)"
         export IMG="$(params.image-url):$(params.image-tag)"
         export BUNDLE_IMG_BASE="$(params.image-url)$(params.image-suffix)"
@@ -114,13 +169,7 @@ spec:
         echo "  operators.operatorframework.io.bundle.channel.default.v1: $(params.default-channel)" >> bundle/metadata/annotations.yaml
         cat bundle/metadata/annotations.yaml
 
-        podman --storage-driver=$(params.STORAGE_DRIVER) build --format=$(params.FORMAT) --tls-verify=$(params.TLSVERIFY) -f $(params.DOCKERFILE) -t ${BUNDLE_IMG} $(params.CONTEXT)
-        set +x
-        if [[ -n "${REGISTRY_USER}" ]] && [[ -n "${REGISTRY_PASSWORD}" ]] && [[ "${IMAGE_SERVER}" != "image-registry.openshift-image-registry.svc:5000"  ]]; then
-          podman login -u "${REGISTRY_USER}" -p "${REGISTRY_PASSWORD}" "${IMAGE_SERVER}"
-          echo "podman login -u "${REGISTRY_USER}" -p "xxxxx" "${IMAGE_SERVER}""
-        fi
-        set -x
-        podman --storage-driver=$(params.STORAGE_DRIVER) push --tls-verify=$(params.TLSVERIFY) --digestfile ./image-digest ${BUNDLE_IMG} docker://${BUNDLE_IMG}
+        podman --authfile=${AUTH_FILE} --storage-driver=$(params.STORAGE_DRIVER) build --format=$(params.FORMAT) --tls-verify=$(params.TLSVERIFY) -f $(params.DOCKERFILE) -t ${BUNDLE_IMG} $(params.CONTEXT)
+        podman --authfile=${AUTH_FILE} --storage-driver=$(params.STORAGE_DRIVER) push --tls-verify=$(params.TLSVERIFY) --digestfile ./image-digest ${BUNDLE_IMG} docker://${BUNDLE_IMG}
 
         echo -n "${BUNDLE_IMG_BASE}" > $(results.bundle-image-url.path)

--- a/tasks/8-image-release.yaml
+++ b/tasks/8-image-release.yaml
@@ -16,7 +16,9 @@ spec:
     - name: image-to
       default: ""
     - name: SKOPEO_IMAGE
-      default: quay.io/containers/skopeo:v1.1.0
+      default: registry.redhat.io/rhel8/skopeo@sha256:7297e3b42ef1d56a5bc1d64a979d05c157bf31b476cc526386c873a89459610a
+    - name: BUILDER_IMAGE
+      default: registry.redhat.io/rhel8/buildah@sha256:23fb7971ea6ac4aaaaa1139473a602df0df19222a3b5a76b551b2b9ddd92e927
     - name: IMAGE_FROM_TLS_VERIFY
       default: "true"
     - name: IMAGE_TO_TLS_VERIFY
@@ -28,8 +30,8 @@ spec:
     - name: varlibcontainers
       emptyDir: {}
   steps:
-    - name: image-tag
-      image: $(params.SKOPEO_IMAGE)
+    - name: setup-docker-auth
+      image: $(params.BUILDER_IMAGE)
       env:
         - name: REGISTRY_USER
           valueFrom:
@@ -43,6 +45,61 @@ spec:
               name: registry-access
               key: REGISTRY_PASSWORD
               optional: true
+        - name: AUTH_CONFIG
+          valueFrom:
+            secretKeyRef:
+              name: registry-auth
+              key: .dockerconfigjson
+              optional: true
+        - name: AUTH_CONFIG_OVERRIDE
+          valueFrom:
+            secretKeyRef:
+              name: registry-auth-local
+              key: .dockerconfigjson
+              optional: true
+        - name: IBM_ENTITLED_REGISTRY_USER
+          valueFrom:
+            secretKeyRef:
+              name: ibm-entitled-registry-credentials
+              key: IBM_ENTITLED_REGISTRY_USER
+              optional: true
+        - name: IBM_ENTITLED_REGISTRY_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: ibm-entitled-registry-credentials
+              key: IBM_ENTITLED_REGISTRY_PASSWORD
+              optional: true
+      volumeMounts:
+        - mountPath: /var/lib/containers
+          name: varlibcontainers
+      script: |
+        if [[ -n "${AUTH_CONFIG_OVERRIDE}" ]]; then
+          AUTH_CONFIG="${AUTH_CONFIG_OVERRIDE}"
+        elif [[ -z "${AUTH_CONFIG}" ]]; then
+          AUTH_CONFIG="{}"
+        fi
+        
+        AUTH_FILE="/var/lib/containers/auth.json"
+        
+        echo "${AUTH_CONFIG}" > "${AUTH_FILE}"
+        
+        if [[ -n "${IBM_ENTITLED_REGISTRY_USER}" ]] && [[ -n "${IBM_ENTITLED_REGISTRY_PASSWORD}" ]]; then
+          buildah login --authfile "${AUTH_FILE}" -u ${IBM_ENTITLED_REGISTRY_USER} -p ${IBM_ENTITLED_REGISTRY_PASSWORD} cp.icr.io
+          echo "buildah login --authfile \"${AUTH_FILE}\" -u \"${IBM_ENTITLED_REGISTRY_USER}\" -p \"xxxxx\" cp.icr.io"
+        fi
+        
+        IMAGE_TO="$(params.image-to)"
+        REGISTRY_SERVER_TO=$(echo "${IMAGE_TO}" | awk -F / '{print $1}')
+        
+        if [[ -n "${REGISTRY_USER}" ]] && [[ -n "${REGISTRY_PASSWORD}" ]] && [[ "${REGISTRY_SERVER_TO}" != "image-registry.openshift-image-registry.svc:5000"  ]]; then
+          buildah login --authfile "${AUTH_FILE}" -u "${REGISTRY_USER}" -p "${REGISTRY_PASSWORD}" "${REGISTRY_SERVER_TO}"
+          echo "buildah login --authfile \"${AUTH_FILE}\" -u \"${REGISTRY_USER}\" -p \"xxxxx\" \"${REGISTRY_SERVER_TO}\""
+        fi
+        
+        echo "Auth file: ${AUTH_FILE}"
+    - name: image-tag
+      image: $(params.SKOPEO_IMAGE)
+      env:
         - name: VAULT_INSTANCE_ID
           valueFrom:
             secretKeyRef:
@@ -76,9 +133,10 @@ spec:
       volumeMounts:
         - mountPath: /var/lib/containers
           name: varlibcontainers
-      securityContext:
-        privileged: true
       script: |
+        AUTH_FILE="/var/lib/containers/auth.json"
+        echo "Auth file: ${AUTH_FILE}"
+        
         IMAGE_FROM="$(params.image-from)"
         REGISTRY_SERVER_FROM=$(echo "${IMAGE_FROM}" | awk -F / '{print $1}')
         IMAGE_TO="$(params.image-to)"
@@ -87,13 +145,6 @@ spec:
         IMAGE_TO_TLS_VERIFY=$(params.IMAGE_TO_TLS_VERIFY)
 
         echo "Tagging ${IMAGE_FROM} as ${IMAGE_TO}"
-        set +x
-        if [[ -n "${REGISTRY_USER}" ]] && [[ -n "${REGISTRY_PASSWORD}" ]] && [[ ! "${REGISTRY_SERVER_FROM}" =~ ":" ]]; then
-          IMAGE_FROM_CREDS="--src-creds ${REGISTRY_USER}:${REGISTRY_PASSWORD}"
-        fi
-        if [[ -n "${REGISTRY_USER}" ]] && [[ -n "${REGISTRY_PASSWORD}" ]] && [[ ! "${REGISTRY_SERVER_TO}" =~ ":" ]]; then
-          IMAGE_TO_CREDS="--dest-creds ${REGISTRY_USER}:${REGISTRY_PASSWORD}"
-        fi
         
         if [[ "${REGISTRY_SERVER_FROM}" =~ ":" ]]; then
           IMAGE_FROM_TLS_VERIFY="false"
@@ -101,7 +152,6 @@ spec:
         if [[ "${REGISTRY_SERVER_TO}" =~ ":" ]]; then
           IMAGE_TO_TLS_VERIFY="false"
         fi
-
 
         SIGNING_PARAMETERS=""
         if [[ -n "$SIGNATURE_FINGERPRINT" ]] ; then
@@ -139,12 +189,10 @@ spec:
           rm -f /etc/containers/registries.d/default.yaml
         fi
 
-        echo "skopeo $SIGNING_PARAMETERS copy --src-tls-verify=${IMAGE_FROM_TLS_VERIFY} --dest-tls-verify=${IMAGE_TO_TLS_VERIFY} docker://${IMAGE_FROM} docker://${IMAGE_TO}"
-        COMMAND="skopeo $SIGNING_PARAMETERS copy ${IMAGE_FROM_CREDS} --src-tls-verify=${IMAGE_FROM_TLS_VERIFY} ${IMAGE_TO_CREDS} --dest-tls-verify=${IMAGE_TO_TLS_VERIFY} docker://${IMAGE_FROM} docker://${IMAGE_TO}"
-        ${COMMAND}
+        echo "skopeo $SIGNING_PARAMETERS copy --authfile=${AUTH_FILE} --src-tls-verify=${IMAGE_FROM_TLS_VERIFY} --dest-tls-verify=${IMAGE_TO_TLS_VERIFY} docker://${IMAGE_FROM} docker://${IMAGE_TO}"
+        skopeo $SIGNING_PARAMETERS copy --authfile="${AUTH_FILE}" --src-tls-verify="${IMAGE_FROM_TLS_VERIFY}" --dest-tls-verify="${IMAGE_TO_TLS_VERIFY}" "docker://${IMAGE_FROM}" "docker://${IMAGE_TO}"
 
         echo -n "${IMAGE_TO}" | tee $(results.image-url.path)
-
 
         if [[ -n "$SIGNATURE_FINGERPRINT" ]] ; then 
 

--- a/tasks/9-img-scan.yaml
+++ b/tasks/9-img-scan.yaml
@@ -35,7 +35,9 @@ spec:
       description: Flag indicating that a scan should be performed with IBM VA
       default: "false"
     - name: SKOPEO_IMAGE
-      default: quay.io/containers/skopeo:v1.1.0
+      default: registry.redhat.io/rhel8/skopeo@sha256:7297e3b42ef1d56a5bc1d64a979d05c157bf31b476cc526386c873a89459610a
+    - name: BUILDER_IMAGE
+      default: registry.redhat.io/rhel8/buildah@sha256:23fb7971ea6ac4aaaaa1139473a602df0df19222a3b5a76b551b2b9ddd92e927
     - name: IMAGE_FROM_TLS_VERIFY
       default: "false"
     - name: TRIVY_IMAGE
@@ -47,6 +49,8 @@ spec:
       emptyDir: {}
     - name: source
       emptyDir: {}
+    - name: varlibcontainers
+      emptyDir: {}
   stepTemplate:
     name: ''
     resources: {}
@@ -54,6 +58,73 @@ spec:
       - mountPath: $(params.source-dir)
         name: source
   steps:
+    - name: setup-docker-auth
+      image: $(params.BUILDER_IMAGE)
+      env:
+        - name: REGISTRY_USER
+          valueFrom:
+            secretKeyRef:
+              name: registry-access
+              key: REGISTRY_USER
+              optional: true
+        - name: REGISTRY_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: registry-access
+              key: REGISTRY_PASSWORD
+              optional: true
+        - name: AUTH_CONFIG
+          valueFrom:
+            secretKeyRef:
+              name: registry-auth
+              key: .dockerconfigjson
+              optional: true
+        - name: AUTH_CONFIG_OVERRIDE
+          valueFrom:
+            secretKeyRef:
+              name: registry-auth-local
+              key: .dockerconfigjson
+              optional: true
+        - name: IBM_ENTITLED_REGISTRY_USER
+          valueFrom:
+            secretKeyRef:
+              name: ibm-entitled-registry-credentials
+              key: IBM_ENTITLED_REGISTRY_USER
+              optional: true
+        - name: IBM_ENTITLED_REGISTRY_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: ibm-entitled-registry-credentials
+              key: IBM_ENTITLED_REGISTRY_PASSWORD
+              optional: true
+      volumeMounts:
+        - mountPath: /var/lib/containers
+          name: varlibcontainers
+      script: |
+        if [[ -n "${AUTH_CONFIG_OVERRIDE}" ]]; then
+          AUTH_CONFIG="${AUTH_CONFIG_OVERRIDE}"
+        elif [[ -z "${AUTH_CONFIG}" ]]; then
+          AUTH_CONFIG="{}"
+        fi
+        
+        AUTH_FILE="/var/lib/containers/auth.json"
+        
+        echo "${AUTH_CONFIG}" > "${AUTH_FILE}"
+        
+        if [[ -n "${IBM_ENTITLED_REGISTRY_USER}" ]] && [[ -n "${IBM_ENTITLED_REGISTRY_PASSWORD}" ]]; then
+          buildah login --authfile "${AUTH_FILE}" -u ${IBM_ENTITLED_REGISTRY_USER} -p ${IBM_ENTITLED_REGISTRY_PASSWORD} cp.icr.io
+          echo "buildah login --authfile \"${AUTH_FILE}\" -u \"${IBM_ENTITLED_REGISTRY_USER}\" -p \"xxxxx\" cp.icr.io"
+        fi
+        
+        IMAGE_URL="$(params.image-url)"
+        REGISTRY_SERVER=$(echo "${IMAGE_URL}" | awk -F / '{print $1}')
+        
+        if [[ -n "${REGISTRY_USER}" ]] && [[ -n "${REGISTRY_PASSWORD}" ]] && [[ "${REGISTRY_SERVER}" != "image-registry.openshift-image-registry.svc:5000"  ]]; then
+          buildah login --authfile "${AUTH_FILE}" -u "${REGISTRY_USER}" -p "${REGISTRY_PASSWORD}" "${REGISTRY_SERVER}"
+          echo "buildah login --authfile \"${AUTH_FILE}\" -u \"${REGISTRY_USER}\" -p \"xxxxx\" \"${REGISTRY_SERVER}\""
+        fi
+        
+        echo "Auth file: ${AUTH_FILE}"
     - name: git-clone
       image: quay.io/ibmgaragecloud/alpine-git
       env:
@@ -89,48 +160,36 @@ spec:
         git checkout $(params.GIT_REVISION)
     - name: trivy-pull
       image: $(params.SKOPEO_IMAGE)
-      env:
-        - name: REGISTRY_USER
-          valueFrom:
-            secretKeyRef:
-              name: registry-access
-              key: REGISTRY_USER
-              optional: true
-        - name: REGISTRY_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: registry-access
-              key: REGISTRY_PASSWORD
-              optional: true
       volumeMounts:
         - mountPath: /var/oci
           name: oci-image
+        - mountPath: /var/lib/containers
+          name: varlibcontainers
       workingDir: $(params.source-dir)
-      securityContext:
-        privileged: true
       script: |
+        AUTH_FILE="/var/lib/containers/auth.json"
+        echo "Auth file: ${AUTH_FILE}"
+        
         set -ex
         PERFORM_SCAN="$(params.scan-trivy)"
         if [[ "${PERFORM_SCAN}" == "false" ]] || [[ -z "${PERFORM_SCAN}" ]]; then
           echo "User selected to skip scanning. Skipping Trivy scan."
           exit 0
         fi
+        
         IMAGE_FROM=$(params.image-url)
         REGISTRY_SERVER_FROM=$(echo "${IMAGE_FROM}" | awk -F / '{print $1}')
         IMAGE_TO="oci:/var/oci/image"
         IMAGE_FROM_TLS_VERIFY=$(params.IMAGE_FROM_TLS_VERIFY)
+        
         echo "Tagging ${IMAGE_FROM} as ${IMAGE_TO}"
-        set +x
-        if [[ -n "${REGISTRY_USER}" ]] && [[ -n "${REGISTRY_PASSWORD}" ]] && [[ "${REGISTRY_SERVER_FROM}" != "image-registry.openshift-image-registry.svc:5000" ]]; then
-          IMAGE_FROM_CREDS="--src-creds ${REGISTRY_USER}:${REGISTRY_PASSWORD}"
-        fi
-        set -x
+        
         if [ "${REGISTRY_SERVER_FROM}" =~ ":" ]; then
           IMAGE_FROM_TLS_VERIFY="false"
         fi
-        echo "skopeo copy --src-creds=xxxx --src-tls-verify=${IMAGE_FROM_TLS_VERIFY} docker://${IMAGE_FROM} ${IMAGE_TO}"
-        set +x
-        skopeo copy ${IMAGE_FROM_CREDS} --src-tls-verify=${IMAGE_FROM_TLS_VERIFY} docker://${IMAGE_FROM} ${IMAGE_TO}
+        
+        echo "skopeo copy --authfile=${AUTH_FILE} --src-tls-verify=${IMAGE_FROM_TLS_VERIFY} docker://${IMAGE_FROM} ${IMAGE_TO}"
+        skopeo copy --authfile=${AUTH_FILE} --src-tls-verify=${IMAGE_FROM_TLS_VERIFY} docker://${IMAGE_FROM} ${IMAGE_TO}
     - name: trivy-scan
       image: $(params.TRIVY_IMAGE)
       volumeMounts:
@@ -184,8 +243,6 @@ spec:
 
           IMAGE_URL=$(params.image-url)
           REGISTRY_SERVER=$(echo $(params.image-url) | awk -F / '{print $1}')
-
-
 
           if [[ ! "${REGISTRY_SERVER}" =~ icr.io ]]; then
             echo "The image is not stored in the IBM Cloud Image Registry. Skipping Vulnerability Advisor validation"


### PR DESCRIPTION
- Removes privileged security constraint from build-tag-push, build-tag-push-ace-bar, image-release, img-scan, and operator-bundle
- Updates docker authentication process in common setup-docker-auth to generate authfile
- Adds support for docker login config in `registry-auth` and `registry-auth-local` secrets
- Updates package-yaml.sh script with additional log messages

closes cloud-native-toolkit/planning#891