### PR TITLE
Change apiVersion fields on tekton tasks

### DIFF
--- a/tasks/12-execute-remote-pipeline.yaml
+++ b/tasks/12-execute-remote-pipeline.yaml
@@ -1,4 +1,4 @@
-apiVersion: tekton.dev/v1alpha1
+apiVersion: tekton.dev/v1beta1
 kind: Task
 metadata:
   name: ibm-execute-remote-pipeline

--- a/tasks/14-manifest-multiarch.yaml
+++ b/tasks/14-manifest-multiarch.yaml
@@ -1,4 +1,4 @@
-apiVersion: tekton.dev/v1alpha1
+apiVersion: tekton.dev/v1beta1
 kind: Task
 metadata:
   name: ibm-manifest-multiarch


### PR DESCRIPTION
Two tekton task files had the wrong apiVersion
This PR should fix the issue

Signed-off-by: Amine RACHYD <aminerachyd99@gmail.com>