### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -22,8 +22,8 @@ jobs:
         run: |
           BRANCH=${GITHUB_REF#refs/heads/}
           echo "Running against branch: ${BRANCH}"
-          echo "::set-output name=branch::${BRANCH}"
-          echo "::set-output name=project::tools-${BRANCH}"
+          echo "branch=${BRANCH}" >> "$GITHUB_OUTPUT"
+          echo "project=tools-${BRANCH}" >> "$GITHUB_OUTPUT"
 
       - name: Cluster login
         run: oc login -u ${{ secrets.CLUSTER_USER }} -p ${{ secrets.CLUSTER_PASSWORD }} ${{ secrets.CLUSTER_SERVER }}


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `set-output` to `$GITHUB_OUTPUT`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter